### PR TITLE
Update tests for modern PHPUnit

### DIFF
--- a/tests/IDS/Tests/CachingTest.php
+++ b/tests/IDS/Tests/CachingTest.php
@@ -17,20 +17,21 @@
  * @package	PHPIDS tests
  */
 namespace IDS\Tests;
+use PHPUnit\Framework\TestCase;
 
 use IDS\Init;
 use IDS\Caching\CacheFactory;
 use IDS\Caching\FileCache;
 use IDS\Caching\SessionCache;
 
-class CachingTest extends \PHPUnit_Framework_TestCase
+class CachingTest extends TestCase
 {
     /**
      * @var Init
      */
     protected $init;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->init = Init::init(IDS_CONFIG);
     }
@@ -102,7 +103,7 @@ class CachingTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($cache->getCache());
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(IDS_FILTER_CACHE_FILE);
     }

--- a/tests/IDS/Tests/EventTest.php
+++ b/tests/IDS/Tests/EventTest.php
@@ -17,18 +17,19 @@
  * @package	PHPIDS tests
  */
 namespace IDS\Tests;
+use PHPUnit\Framework\TestCase;
 
 use IDS\Event;
 use IDS\Filter;
 
-class EventTest extends \PHPUnit_Framework_TestCase
+class EventTest extends TestCase
 {
     /**
      * @var Event
      */
     protected $event;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->event = new Event("handled_key", "my val",
             array(

--- a/tests/IDS/Tests/ExceptionTest.php
+++ b/tests/IDS/Tests/ExceptionTest.php
@@ -17,6 +17,7 @@
  * @package	PHPIDS tests
  */
 namespace IDS\Tests;
+use PHPUnit\Framework\TestCase;
 
 use IDS\Report;
 use IDS\Event;
@@ -24,7 +25,7 @@ use IDS\Filter;
 use IDS\Init;
 use IDS\Monitor;
 
-class ExceptionTest extends \PHPUnit_Framework_TestCase
+class ExceptionTest extends TestCase
 {
     /**
      * @var Report
@@ -36,7 +37,7 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
      */
     protected $init;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->report = new Report(array(
             new Event("key_a", 'val_b',
@@ -58,7 +59,7 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
 
     public function testEventConstructorExceptions1()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         new Event(array(1,2), 'val_b',
                 array(
                     new Filter(1, '^test_a1$', 'desc_a1', array('tag_a1', 'tag_a2'), 1),
@@ -69,7 +70,7 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
 
     public function testEventConstructorExceptions2()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         new Event("key_a", array(1,2),
                 array(
                     new Filter(1, '^test_a1$', 'desc_a1', array('tag_a1', 'tag_a2'), 1),
@@ -80,31 +81,31 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
 
     public function testEventConstructorExceptions3()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         new Event("key_a", 'val_b', array(1,2));
     }
 
     public function testGetEventException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->report->getEvent(array(1,2,3));
     }
 
     public function testHasEventException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->report->hasEvent(array(1,2,3));
     }
 
     public function testInitConfigWrongPathException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Init::init('IDS/Config/Config.ini.wrong');
     }
 
     public function testWrongXmlFilterPathException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->init->config['General']['filter_type'] = 'xml';
         $this->init->config['General']['filter_path'] = 'IDS/wrong_path';
         new Monitor($this->init);

--- a/tests/IDS/Tests/FilterSetTest.php
+++ b/tests/IDS/Tests/FilterSetTest.php
@@ -17,12 +17,13 @@
  * @package    PHPIDS tests
  */
 namespace IDS\Tests;
+use PHPUnit\Framework\TestCase;
 
 use IDS\Init;
 use IDS\Filter;
 use IDS\Filter\Storage;
 
-class FilterSetTest extends \PHPUnit_Framework_TestCase
+class FilterSetTest extends TestCase
 {
     /**
      * @var array
@@ -34,7 +35,7 @@ class FilterSetTest extends \PHPUnit_Framework_TestCase
      */
     protected $xmlFilter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->jsonFilter = $this->getFilterset('json');
         $this->xmlFilter = $this->getFilterSet('xml');

--- a/tests/IDS/Tests/FilterTest.php
+++ b/tests/IDS/Tests/FilterTest.php
@@ -17,19 +17,20 @@
  * @package	PHPIDS tests
  */
 namespace IDS\Tests;
+use PHPUnit\Framework\TestCase;
 
 use IDS\Filter;
 use IDS\Filter\Storage;
 use IDS\Init;
 
-class FilterTest extends \PHPUnit_Framework_TestCase
+class FilterTest extends TestCase
 {
     /**
      * @var Init
      */
     protected $init;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->init = Init::init(IDS_CONFIG);
     }
@@ -59,20 +60,20 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testInvalidArgumentOnMatch () {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $filter = new Filter(1, '^test$', 'My description', array('foo', 'bar'), 10);
         $filter->match(1);
     }
 
     public function testInvalidArgumentInFilterInstanciation1 () {
         $this->markTestSkipped('The values are not validated properly on instanciation');
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         new Filter(1, '^test$', 'my desc', array('foo'), 'test');
     }
 
     public function testInvalidArgumentInFilterInstanciation2 () {
         $this->markTestSkipped('The values are not validated properly on instanciation');
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         new Filter(1, 1, 'my desc', array("foo"), 'bla');
     }
 

--- a/tests/IDS/Tests/InitTest.php
+++ b/tests/IDS/Tests/InitTest.php
@@ -17,17 +17,18 @@
  * @package    PHPIDS tests
  */
 namespace IDS\Tests;
+use PHPUnit\Framework\TestCase;
 
 use IDS\Init;
 
-class InitTest extends \PHPUnit_Framework_TestCase
+class InitTest extends TestCase
 {
     /**
      * @var \IDS\Init
      */
     private $init = null;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->init = Init::init(IDS_CONFIG);
     }

--- a/tests/IDS/Tests/MonitorTest.php
+++ b/tests/IDS/Tests/MonitorTest.php
@@ -17,6 +17,7 @@
  * @package	PHPIDS tests
  */
 namespace IDS\Tests;
+use PHPUnit\Framework\TestCase;
 
 use IDS\Monitor;
 use IDS\Init;
@@ -25,14 +26,14 @@ use IDS\Report;
 /**
  * @large
  */
-class MonitorTest extends \PHPUnit_Framework_TestCase
+class MonitorTest extends TestCase
 {
     /**
      * @var Init
      */
     protected $init;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->init = Init::init(IDS_CONFIG);
         $this->init->config['General']['filter_type'] = IDS_FILTER_TYPE;

--- a/tests/IDS/Tests/ReportTest.php
+++ b/tests/IDS/Tests/ReportTest.php
@@ -17,19 +17,20 @@
  * @package	PHPIDS tests
  */
 namespace IDS\Tests;
+use PHPUnit\Framework\TestCase;
 
 use IDS\Report;
 use IDS\Event;
 use IDS\Filter;
 
-class ReportTest extends \PHPUnit_Framework_TestCase
+class ReportTest extends TestCase
 {
     /**
      * @var Report
      */
     protected $report;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->report = new Report(array(
             new Event("key_a", 'val_b',

--- a/tests/IDS/Tests/RuleTest.php
+++ b/tests/IDS/Tests/RuleTest.php
@@ -17,11 +17,12 @@
  * @package    PHPIDS tests
  */
 namespace IDS\Tests;
+use PHPUnit\Framework\TestCase;
 
 use IDS\Init;
 use IDS\Monitor;
 
-class RuleTest extends \PHPUnit_Framework_TestCase
+class RuleTest extends TestCase
 {
     /**
      * @var Init
@@ -47,7 +48,7 @@ class RuleTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->init = Init::init(IDS_CONFIG);
         $this->init->config['General']['tmp_path'] = IDS_TEMP_DIR;

--- a/tests/IDS/Tests/VersionTest.php
+++ b/tests/IDS/Tests/VersionTest.php
@@ -17,10 +17,11 @@
  * @package	PHPIDS tests
  */
 namespace IDS\Tests;
+use PHPUnit\Framework\TestCase;
 
 use IDS\Version;
 
-class VersionTest extends \PHPUnit_Framework_TestCase
+class VersionTest extends TestCase
 {
     public function testVersionConstantIsDefined()
     {


### PR DESCRIPTION
## Summary
- modernize the test suite for compatibility with current PHPUnit

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist tests/IDS/Tests/InitTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b3087ab48325b34cef0eb3c5ce56