### PR TITLE
Add phpstan to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,8 @@
             "IDS\\Tests": "tests/",
             "IDS": "lib/"
         }
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^1.11"
     }
 }


### PR DESCRIPTION
## Summary
- add phpstan as a `require-dev` dependency in composer.json

## Testing
- `./vendor/bin/phpstan analyse --level 1` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f099770c88325b9b686c4719ad25b