### PR TITLE
Fix phpstan level 1 errors

### DIFF
--- a/lib/IDS/Caching/DatabaseCache.php
+++ b/lib/IDS/Caching/DatabaseCache.php
@@ -238,7 +238,7 @@ class DatabaseCache implements CacheInterface
      * @param object $handle the database handle
      * @param array  $data   the caching data
      *
-     * @return object       PDO
+     * @return void
      * @throws PDOException if a db error occurred
      */
     private function write($handle, $data)

--- a/lib/IDS/Converter.php
+++ b/lib/IDS/Converter.php
@@ -415,7 +415,7 @@ class Converter
         preg_match_all('/(?:^|[,&?])\s*([a-z0-9]{50,}=*)(?:\W|$)/im', $value, $matches);
 
         foreach ($matches[1] as $item) {
-            if (isset($item) && !preg_match('/[a-f0-9]{32}/i', $item)) {
+            if (!preg_match('/[a-f0-9]{32}/i', $item)) {
                 $base64_item = base64_decode($item);
                 $value = str_replace($item, $base64_item, $value);
             }
@@ -691,7 +691,7 @@ class Converter
      * @static
      * @return string
      */
-    public static function runCentrifuge($value, Monitor $monitor = null)
+    public static function runCentrifuge($value, ?Monitor $monitor = null)
     {
         $threshold = 3.49;
         if (strlen($value) > 25) {

--- a/lib/IDS/Event.php
+++ b/lib/IDS/Event.php
@@ -202,6 +202,7 @@ class Event implements \Countable, \IteratorAggregate
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->getFilters());
@@ -214,6 +215,7 @@ class Event implements \Countable, \IteratorAggregate
      *
      * @return \Iterator the filter collection
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->getFilters());

--- a/lib/IDS/Filter.php
+++ b/lib/IDS/Filter.php
@@ -51,6 +51,13 @@ namespace IDS;
 class Filter
 {
     /**
+     * Filter ID
+     *
+     * @var integer
+     */
+    protected $id = 0;
+
+    /**
      * Filter rule
      *
      * @var string

--- a/lib/IDS/Init.php
+++ b/lib/IDS/Init.php
@@ -59,7 +59,7 @@ class Init
     /**
      * Instance of this class depending on the supplied config file
      *
-     * @var Init[]|array
+     * @var array<string, static>
      * @static
      */
     private static $instances = array();
@@ -85,7 +85,7 @@ class Init
      * @param string|null $configPath the path to the config file
      *
      * @throws \InvalidArgumentException
-     * @return self
+     * @return static
      */
     public static function init($configPath = null)
     {
@@ -96,7 +96,7 @@ class Init
             if (!file_exists($configPath) || !is_readable($configPath)) {
                 throw new \InvalidArgumentException("Invalid config path '$configPath'");
             }
-            self::$instances[$configPath] = new static(parse_ini_file($configPath, true));
+            self::$instances[$configPath] = new self(parse_ini_file($configPath, true));
         }
 
         return self::$instances[$configPath];

--- a/lib/IDS/Monitor.php
+++ b/lib/IDS/Monitor.php
@@ -140,7 +140,7 @@ class Monitor
      * @param  array|null $tags list of tags to which filters should be applied
      * @return Monitor
      */
-    public function __construct(Init $init, array $tags = null)
+    public function __construct(Init $init, ?array $tags = null)
     {
         $this->storage    = new Storage($init);
         $this->tags       = $tags;

--- a/lib/IDS/Report.php
+++ b/lib/IDS/Report.php
@@ -95,7 +95,7 @@ class Report implements \Countable, \IteratorAggregate
      *
      * @return Report
      */
-    public function __construct(array $events = null)
+    public function __construct(?array $events = null)
     {
         foreach ((array) $events as $event) {
             $this->addEvent($event);
@@ -199,6 +199,7 @@ class Report implements \Countable, \IteratorAggregate
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->events);
@@ -213,6 +214,7 @@ class Report implements \Countable, \IteratorAggregate
      *
      * @return \Iterator the event collection
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->events);


### PR DESCRIPTION
## Summary
- clean up `DatabaseCache::write` return type
- drop redundant `isset` check in `Converter`
- allow `null` for optional parameters
- silence return type mismatches with `#[ReturnTypeWillChange]`
- document and return proper types in `Init`
- add missing `id` property to `Filter`
- run phpstan at level 1

## Testing
- `./vendor/bin/phpstan analyse lib --level=1 --no-progress`
- `phpunit --configuration phpunit.xml.dist --dont-report-useless-tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0ade9b908325be2b401fc3042ded