### PR TITLE
Fix PHPStan level 2 issues

### DIFF
--- a/lib/IDS/Caching/ApcCache.php
+++ b/lib/IDS/Caching/ApcCache.php
@@ -78,8 +78,8 @@ class ApcCache implements CacheInterface
     /**
      * Constructor
      *
-     * @param string $type caching type
-     * @param array  $init the IDS_Init object
+     * @param string   $type caching type
+     * @param \IDS\Init $init the IDS_Init object
      *
      * @return void
      */
@@ -92,8 +92,8 @@ class ApcCache implements CacheInterface
     /**
      * Returns an instance of this class
      *
-     * @param string $type caching type
-     * @param object $init the IDS_Init object
+     * @param string   $type caching type
+     * @param \IDS\Init $init the IDS_Init object
      *
      * @return object $this
      */

--- a/lib/IDS/Caching/DatabaseCache.php
+++ b/lib/IDS/Caching/DatabaseCache.php
@@ -104,8 +104,8 @@ class DatabaseCache implements CacheInterface
      *
      * Connects to database.
      *
-     * @param string $type caching type
-     * @param object $init the IDS_Init object
+     * @param string   $type caching type
+     * @param \IDS\Init $init the IDS_Init object
      *
      * @return void
      */
@@ -120,8 +120,8 @@ class DatabaseCache implements CacheInterface
      * Returns an instance of this class
      *
      * @static
-     * @param string $type caching type
-     * @param object $init the IDS_Init object
+     * @param string   $type caching type
+     * @param \IDS\Init $init the IDS_Init object
      *
      * @return object $this
      */
@@ -140,7 +140,7 @@ class DatabaseCache implements CacheInterface
      *
      * @param array $data the caching data
      *
-     * @throws PDOException if a db error occurred
+     * @throws \PDOException if a db error occurred
      * @return object       $this
      */
     public function setCache(array $data)
@@ -173,7 +173,7 @@ class DatabaseCache implements CacheInterface
      * Note that this method returns false if either type or file cache is
      * not set
      *
-     * @throws PDOException if a db error occurred
+     * @throws \PDOException if a db error occurred
      * @return mixed        cache data or false
      */
     public function getCache()
@@ -202,8 +202,8 @@ class DatabaseCache implements CacheInterface
      * Connect to database and return a handle
      *
      * @return object       PDO
-     * @throws Exception    if connection parameters are faulty
-     * @throws PDOException if a db error occurred
+     * @throws \Exception    if connection parameters are faulty
+     * @throws \PDOException if a db error occurred
      */
     private function connect()
     {
@@ -239,7 +239,7 @@ class DatabaseCache implements CacheInterface
      * @param array  $data   the caching data
      *
      * @return void
-     * @throws PDOException if a db error occurred
+     * @throws \PDOException if a db error occurred
      */
     private function write($handle, $data)
     {

--- a/lib/IDS/Caching/FileCache.php
+++ b/lib/IDS/Caching/FileCache.php
@@ -81,8 +81,8 @@ class FileCache implements CacheInterface
     /**
      * Constructor
      *
-     * @param string $type caching type
-     * @param object $init the IDS_Init object
+     * @param string   $type caching type
+     * @param \IDS\Init $init the IDS_Init object
      * @throws \Exception
      *
      * @return void
@@ -105,8 +105,8 @@ class FileCache implements CacheInterface
     /**
      * Returns an instance of this class
      *
-     * @param string $type caching type
-     * @param object $init the IDS_Init object
+     * @param string   $type caching type
+     * @param \IDS\Init $init the IDS_Init object
      *
      * @return object $this
      */
@@ -124,7 +124,7 @@ class FileCache implements CacheInterface
      *
      * @param array $data the cache data
      *
-     * @throws Exception if cache file couldn't be created
+     * @throws \Exception if cache file couldn't be created
      * @return object    $this
      */
     public function setCache(array $data)

--- a/lib/IDS/Caching/MemcachedCache.php
+++ b/lib/IDS/Caching/MemcachedCache.php
@@ -86,8 +86,8 @@ class MemcachedCache implements CacheInterface
     /**
      * Constructor
      *
-     * @param string $type caching type
-     * @param array  $init the IDS_Init object
+     * @param string   $type caching type
+     * @param \IDS\Init $init the IDS_Init object
      *
      * @return void
      */
@@ -103,8 +103,8 @@ class MemcachedCache implements CacheInterface
     /**
      * Returns an instance of this class
      *
-     * @param string $type caching type
-     * @param object $init the IDS_Init object
+     * @param string   $type caching type
+     * @param \IDS\Init $init the IDS_Init object
      *
      * @return object $this
      */
@@ -160,7 +160,7 @@ class MemcachedCache implements CacheInterface
     /**
      * Connect to the memcached server
      *
-     * @throws Exception if connection parameters are insufficient
+     * @throws \Exception if connection parameters are insufficient
      * @return void
      */
     private function connect()

--- a/lib/IDS/Filter/Storage.php
+++ b/lib/IDS/Filter/Storage.php
@@ -85,7 +85,7 @@ class Storage
      *
      * Loads filters based on provided IDS_Init settings.
      *
-     * @param object $init IDS_Init instance
+     * @param \IDS\Init $init IDS_Init instance
      *
      * @throws \InvalidArgumentException if unsupported filter type is given
      * @return void
@@ -144,7 +144,7 @@ class Storage
     /**
      * Adds a filter
      *
-     * @param object $filter IDS_Filter instance
+     * @param \IDS\Filter $filter IDS_Filter instance
      *
      * @return object $this
      */

--- a/lib/IDS/Monitor.php
+++ b/lib/IDS/Monitor.php
@@ -132,6 +132,13 @@ class Monitor
     private $tmpJsonString = '';
 
     /**
+     * Centrifuge data container
+     *
+     * @var array
+     */
+    public $centrifuge = array();
+
+    /**
      * Constructor
      *
      * @throws \InvalidArgumentException When PHP version is less than what the library supports
@@ -294,7 +301,7 @@ class Monitor
                 throw new \Exception($this->HTMLPurifierCache . ' must be writeable');
             }
 
-            /** @var $config \HTMLPurifier_Config */
+            /** @var \HTMLPurifier_Config $config */
             $config = \HTMLPurifier_Config::createDefault();
             $config->set('Attr.EnableID', true);
             $config->set('Cache.SerializerPath', $this->HTMLPurifierCache);


### PR DESCRIPTION
## Summary
- run PHPStan at level 2
- fix docblocks with incorrect types
- ensure `Monitor` defines a `centrifuge` property
- qualify exception types for PHPStan

## Testing
- `vendor/bin/phpstan analyse -l 2 lib`
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f0c341f488325885370e98820b721