### PR TITLE
Run PHPStan level 4 and fix findings

### DIFF
--- a/lib/IDS/Caching/ApcCache.php
+++ b/lib/IDS/Caching/ApcCache.php
@@ -47,12 +47,6 @@ namespace IDS\Caching;
  */
 class ApcCache implements CacheInterface
 {
-    /**
-     * Caching type
-     *
-     * @var string
-     */
-    private $type = null;
 
     /**
      * Cache configuration
@@ -71,36 +65,33 @@ class ApcCache implements CacheInterface
     /**
      * Holds an instance of this class
      *
-     * @var object
+     * @var self|null
      */
     private static $cachingInstance = null;
 
     /**
      * Constructor
      *
-     * @param string   $type caching type
      * @param \IDS\Init $init the IDS_Init object
      *
      * @return void
      */
-    public function __construct($type, $init)
+    public function __construct($init)
     {
-        $this->type   = $type;
         $this->config = $init->config['Caching'];
     }
 
     /**
      * Returns an instance of this class
      *
-     * @param string   $type caching type
      * @param \IDS\Init $init the IDS_Init object
      *
      * @return object $this
      */
-    public static function getInstance($type, $init)
+    public static function getInstance($init)
     {
         if (!self::$cachingInstance) {
-            self::$cachingInstance = new ApcCache($type, $init);
+            self::$cachingInstance = new ApcCache($init);
         }
 
         return self::$cachingInstance;

--- a/lib/IDS/Caching/CacheFactory.php
+++ b/lib/IDS/Caching/CacheFactory.php
@@ -72,11 +72,12 @@ class CacheFactory
             include_once $path;
 
             if (class_exists($class)) {
-                $object = call_user_func(
-                    array('' . $class, 'getInstance'),
-                    $type,
-                    $init
-                );
+                $method = new \ReflectionMethod($class, 'getInstance');
+                $args = $method->getNumberOfParameters() === 2
+                    ? array($type, $init)
+                    : array($init);
+
+                $object = $method->invokeArgs(null, $args);
             }
         }
 

--- a/lib/IDS/Caching/DatabaseCache.php
+++ b/lib/IDS/Caching/DatabaseCache.php
@@ -86,16 +86,16 @@ class DatabaseCache implements CacheInterface
     private $config = null;
 
     /**
-     * DBH
+     * Database connection handle
      *
-     * @var object
+     * @var \PDO|null
      */
     private $handle = null;
 
     /**
      * Holds an instance of this class
      *
-     * @var object
+     * @var self|null
      */
     private static $cachingInstance = null;
 

--- a/lib/IDS/Caching/FileCache.php
+++ b/lib/IDS/Caching/FileCache.php
@@ -50,12 +50,6 @@ use IDS\Init;
  */
 class FileCache implements CacheInterface
 {
-    /**
-     * Caching type
-     *
-     * @var string
-     */
-    private $type;
 
     /**
      * Cache configuration
@@ -74,22 +68,20 @@ class FileCache implements CacheInterface
     /**
      * Holds an instance of this class
      *
-     * @var object
+     * @var self|null
      */
     private static $cachingInstance;
 
     /**
      * Constructor
      *
-     * @param string   $type caching type
      * @param \IDS\Init $init the IDS_Init object
      * @throws \Exception
      *
      * @return void
      */
-    public function __construct($type, Init $init)
+    public function __construct(Init $init)
     {
-        $this->type   = $type;
         $this->config = $init->config['Caching'];
         $this->path   = $init->getBasePath() . $this->config['path'];
 
@@ -105,15 +97,14 @@ class FileCache implements CacheInterface
     /**
      * Returns an instance of this class
      *
-     * @param string   $type caching type
      * @param \IDS\Init $init the IDS_Init object
      *
      * @return object $this
      */
-    public static function getInstance($type, $init)
+    public static function getInstance($init)
     {
         if (!self::$cachingInstance) {
-            self::$cachingInstance = new FileCache($type, $init);
+            self::$cachingInstance = new FileCache($init);
         }
 
         return self::$cachingInstance;

--- a/lib/IDS/Caching/MemcachedCache.php
+++ b/lib/IDS/Caching/MemcachedCache.php
@@ -48,12 +48,6 @@ namespace IDS\Caching;
  */
 class MemcachedCache implements CacheInterface
 {
-    /**
-     * Caching type
-     *
-     * @var string
-     */
-    private $type = null;
 
     /**
      * Cache configuration
@@ -79,22 +73,20 @@ class MemcachedCache implements CacheInterface
     /**
      * Holds an instance of this class
      *
-     * @var object
+     * @var self|null
      */
     private static $cachingInstance = null;
 
     /**
      * Constructor
      *
-     * @param string   $type caching type
      * @param \IDS\Init $init the IDS_Init object
      *
      * @return void
      */
-    public function __construct($type, $init)
+    public function __construct($init)
     {
-
-        $this->type   = $type;
+        
         $this->config = $init->config['Caching'];
 
         $this->connect();
@@ -103,15 +95,14 @@ class MemcachedCache implements CacheInterface
     /**
      * Returns an instance of this class
      *
-     * @param string   $type caching type
      * @param \IDS\Init $init the IDS_Init object
      *
      * @return object $this
      */
-    public static function getInstance($type, $init)
+    public static function getInstance($init)
     {
         if (!self::$cachingInstance) {
-            self::$cachingInstance = new MemcachedCache($type, $init);
+            self::$cachingInstance = new MemcachedCache($init);
         }
 
         return self::$cachingInstance;

--- a/lib/IDS/Caching/SessionCache.php
+++ b/lib/IDS/Caching/SessionCache.php
@@ -66,7 +66,7 @@ class SessionCache implements CacheInterface
     /**
      * Holds an instance of this class
      *
-     * @var object
+     * @var self|null
      */
     private static $cachingInstance = null;
 

--- a/lib/IDS/Filter/Storage.php
+++ b/lib/IDS/Filter/Storage.php
@@ -69,7 +69,7 @@ class Storage
     /**
      * Cache container
      *
-     * @var object IDS_Caching wrapper
+     * @var object|null IDS_Caching wrapper
      */
     protected $cache = null;
 

--- a/lib/IDS/Init.php
+++ b/lib/IDS/Init.php
@@ -144,18 +144,16 @@ class Init
      * @param  array $successor The hash which values count more when in doubt
      * @return array Merged hash
      */
-    protected function mergeConfig($current, $successor)
+    protected function mergeConfig(array $current, array $successor)
     {
-        if (is_array($current) and is_array($successor)) {
-            foreach ($successor as $key => $value) {
-                if (isset($current[$key])
-                    and is_array($value)
-                    and is_array($current[$key])) {
+        foreach ($successor as $key => $value) {
+            if (isset($current[$key])
+                && is_array($value)
+                && is_array($current[$key])) {
 
-                    $current[$key] = $this->mergeConfig($current[$key], $value);
-                } else {
-                    $current[$key] = $successor[$key];
-                }
+                $current[$key] = $this->mergeConfig($current[$key], $value);
+            } else {
+                $current[$key] = $successor[$key];
             }
         }
 

--- a/lib/IDS/Monitor.php
+++ b/lib/IDS/Monitor.php
@@ -226,7 +226,7 @@ class Monitor
         // check if this field is part of the exceptions
         foreach ($this->exceptions as $exception) {
             $matches = array();
-            if (($exception === $key) || preg_match('((/.*/[^eE]*)$)', $exception, $matches) && isset($matches[1]) && preg_match($matches[1], $key)) {
+            if (($exception === $key) || (preg_match('((/.*/[^eE]*)$)', $exception, $matches) && preg_match($matches[1], $key))) {
                 return array();
             }
         }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: 4
+    paths:
+        - lib
+    excludePaths:
+        - lib/IDS/Config/Config.ini.php


### PR DESCRIPTION
## Summary
- configure PHPStan
- fix static cache singleton docs
- remove unused cache type parameters
- update CacheFactory for variable constructor signatures
- mark cache property nullable
- simplify mergeConfig
- handle exception check correctly

## Testing
- `./vendor/bin/phpstan analyse --configuration=phpstan.neon`

------
https://chatgpt.com/codex/tasks/task_e_685f0ee73a6483258b64723a4a9d02fb