### PR TITLE
Fix phpstan level 5 errors

### DIFF
--- a/lib/IDS/Caching/CacheFactory.php
+++ b/lib/IDS/Caching/CacheFactory.php
@@ -62,7 +62,7 @@ class CacheFactory
         $object  = false;
         $wrapper = preg_replace(
             '/\W+/m',
-            null,
+            '',
             ucfirst($init->config['Caching']['caching'])
         );
         $class   = '\\IDS\\Caching\\' . $wrapper . 'Cache';

--- a/lib/IDS/Caching/FileCache.php
+++ b/lib/IDS/Caching/FileCache.php
@@ -120,7 +120,7 @@ class FileCache implements CacheInterface
      */
     public function setCache(array $data)
     {
-        if (!is_writable(preg_replace('/[\/][^\/]+\.[^\/]++$/', null, $this->path))) {
+        if (!is_writable(preg_replace('/[\/][^\/]+\.[^\/]++$/', '', $this->path))) {
             throw new \Exception(
                 'Temp directory ' .
                 htmlspecialchars($this->path, ENT_QUOTES, 'UTF-8') .

--- a/lib/IDS/Converter.php
+++ b/lib/IDS/Converter.php
@@ -153,14 +153,14 @@ class Converter
                 $char = preg_replace('/\W0/s', '', $char);
 
                 if (preg_match_all('/\d*[+-\/\* ]\d+/', $char, $matches)) {
-                    $match = preg_split('/(\W?\d+)/', implode('', $matches[0]), null, PREG_SPLIT_DELIM_CAPTURE);
+                    $match = preg_split('/(\W?\d+)/', implode('', $matches[0]), -1, PREG_SPLIT_DELIM_CAPTURE);
 
                     if (array_sum($match) >= 20 && array_sum($match) <= 127) {
                         $converted .= chr(array_sum($match));
                     }
 
                 } elseif (!empty($char) && $char >= 20 && $char <= 127) {
-                    $converted .= chr($char);
+                    $converted .= chr((int) $char);
                 }
             }
 
@@ -321,7 +321,7 @@ class Converter
         $value   = preg_replace($pattern, '!', $value);
         $value   = preg_replace('/"\s+\d/', '"', $value);
         $value   = preg_replace('/(\W)div(\W)/ims', '$1 OR $2', $value);
-        $value   = preg_replace('/\/(?:\d+|null)/', null, $value);
+        $value   = preg_replace('/\/(?:\d+|null)/', '', $value);
 
         return $value;
     }
@@ -350,7 +350,7 @@ class Converter
         $value = urldecode(
             preg_replace(
                 '/(?:%E(?:2|3)%8(?:0|1)%(?:A|8|9)\w|%EF%BB%BF|%EF%BF%BD)|(?:&#(?:65|8)\d{3};?)/i',
-                null,
+                '',
                 urlencode($value)
             )
         );
@@ -362,13 +362,13 @@ class Converter
         $value = urldecode($value);
 
         $value = preg_replace('/(?:%ff1c)/', '<', $value);
-        $value = preg_replace('/(?:&[#x]*(200|820|200|820|zwn?j|lrm|rlm)\w?;?)/i', null, $value);
+        $value = preg_replace('/(?:&[#x]*(200|820|200|820|zwn?j|lrm|rlm)\w?;?)/i', '', $value);
         $value = preg_replace(
             '/(?:&#(?:65|8)\d{3};?)|' .
             '(?:&#(?:56|7)3\d{2};?)|' .
             '(?:&#x(?:fe|20)\w{2};?)|' .
             '(?:&#x(?:d[c-f])\w{2};?)/i',
-            null,
+            '',
             $value
         );
 
@@ -587,7 +587,7 @@ class Converter
         );
 
         // strip out concatenations
-        $converted = preg_replace($pattern, null, $compare);
+        $converted = preg_replace($pattern, '', $compare);
 
         //strip object traversal
         $converted = preg_replace('/\w(\.\w\()/', "$1", $converted);
@@ -598,7 +598,7 @@ class Converter
         //convert JS special numbers
         $converted = preg_replace(
             '/(?:\(*[.\d]e[+-]*[^a-z\W]+\)*)|(?:NaN|Infinity)\W/ims',
-            1,
+            '1',
             $converted
         );
 
@@ -629,15 +629,15 @@ class Converter
         $value = preg_replace('/^"([^"=\\!><~]+)"$/', '$1', $value);
 
         //OpenID login tokens
-        $value = preg_replace('/{[\w-]{8,9}\}(?:\{[\w=]{8}\}){2}/', null, $value);
+        $value = preg_replace('/{[\w-]{8,9}\}(?:\{[\w=]{8}\}){2}/', '', $value);
 
         //convert Content and \sdo\s to null
-        $value = preg_replace('/Content|\Wdo\s/', null, $value);
+        $value = preg_replace('/Content|\Wdo\s/', '', $value);
 
         //strip emoticons
         $value = preg_replace(
             '/(?:\s[:;]-[)\/PD]+)|(?:\s;[)PD]+)|(?:\s:[)PD]+)|-\.-|\^\^/m',
-            null,
+            '',
             $value
         );
 
@@ -696,7 +696,7 @@ class Converter
         $threshold = 3.49;
         if (strlen($value) > 25) {
             //strip padding
-            $tmp_value = preg_replace('/\s{4}|==$/m', null, $value);
+            $tmp_value = preg_replace('/\s{4}|==$/m', '', $value);
             $tmp_value = preg_replace(
                 '/\s{4}|[\p{L}\d\+\-=,.%()]{8,}/m',
                 'aaa',
@@ -705,12 +705,12 @@ class Converter
 
             // Check for the attack char ratio
             $tmp_value = preg_replace('/([*.!?+-])\1{1,}/m', '$1', $tmp_value);
-            $tmp_value = preg_replace('/"[\p{L}\d\s]+"/m', null, $tmp_value);
+            $tmp_value = preg_replace('/"[\p{L}\d\s]+"/m', '', $tmp_value);
 
             $stripped_length = strlen(
                 preg_replace(
                     '/[\d\s\p{L}\.:,%&\/><\-)!|]+/m',
-                    null,
+                    '',
                     $tmp_value
                 )
             );
@@ -718,7 +718,7 @@ class Converter
                 preg_replace(
                     '/([\d\s\p{L}:,\.]{3,})+/m',
                     'aaa',
-                    preg_replace('/\s{2,}/m', null, $tmp_value)
+                    preg_replace('/\s{2,}/m', '', $tmp_value)
                 )
             );
 
@@ -732,7 +732,7 @@ class Converter
 
         if (strlen($value) > 40) {
             // Replace all non-special chars
-            $converted =  preg_replace('/[\w\s\p{L},.:!]/', null, $value);
+            $converted =  preg_replace('/[\w\s\p{L},.:!]/', '', $value);
 
             // Split string into an array, unify and sort
             $array = str_split($converted);
@@ -760,7 +760,7 @@ class Converter
             $converted = preg_replace('/[+-]\s*\d+/', '+', $converted);
             $converted = preg_replace('/[()[\]{}]/', '(', $converted);
             $converted = preg_replace('/[!?:=]/', ':', $converted);
-            $converted = preg_replace('/[^:(+]/', null, stripslashes($converted));
+            $converted = preg_replace('/[^:(+]/', '', stripslashes($converted));
 
             // Sort again and implode
             $array = str_split($converted);

--- a/lib/IDS/Filter/Storage.php
+++ b/lib/IDS/Filter/Storage.php
@@ -244,7 +244,7 @@ class Storage
                 
                     $this->addFilter(
                             new \IDS\Filter(
-                                    $id,
+                                    (int) $id,
                                     $rule,
                                     $description,
                                     (array) $tags[0],
@@ -337,7 +337,7 @@ class Storage
     
                     $this->addFilter(
                         new \IDS\Filter(
-                            $id,
+                            (int) $id,
                             $rule,
                             $description,
                             (array) $tags[0],

--- a/lib/IDS/Monitor.php
+++ b/lib/IDS/Monitor.php
@@ -341,8 +341,8 @@ class Monitor
         /*
          * Remove control chars before pre-check
          */
-        $tmpValue = preg_replace('/\p{C}/', null, $value);
-        $tmpKey = preg_replace('/\p{C}/', null, $key);
+        $tmpValue = preg_replace('/\p{C}/', '', $value);
+        $tmpKey = preg_replace('/\p{C}/', '', $key);
 
         $preCheck = '/<(script|iframe|applet|object)\W/i';
         return !(preg_match($preCheck, $tmpKey) || preg_match($preCheck, $tmpValue));
@@ -365,10 +365,10 @@ class Monitor
          * deal with over-sensitive alt-attribute addition of the purifier
          * and other common html formatting problems
          */
-        $purified = preg_replace('/\s+alt="[^"]*"/m', null, $purified);
-        $purified = preg_replace('/=?\s*"\s*"/m', null, $purified);
-        $original = preg_replace('/\s+alt="[^"]*"/m', null, $original);
-        $original = preg_replace('/=?\s*"\s*"/m', null, $original);
+        $purified = preg_replace('/\s+alt="[^"]*"/m', '', $purified);
+        $purified = preg_replace('/=?\s*"\s*"/m', '', $purified);
+        $original = preg_replace('/\s+alt="[^"]*"/m', '', $original);
+        $original = preg_replace('/=?\s*"\s*"/m', '', $original);
         $original = preg_replace('/style\s*=\s*([^"])/m', 'style = "$1', $original);
 
         # deal with oversensitive CSS normalization


### PR DESCRIPTION
## Summary
- run phpstan at level 5 and fix reported issues
- sanitize regex replacements in caching and conversion code
- cast filter IDs to int in Storage
- remove unused `null` replacements in Monitor

## Testing
- `./vendor/bin/phpstan analyse -l 5`

------
https://chatgpt.com/codex/tasks/task_e_685f10ed7b708325b5216c1e6e206fab