### PR TITLE
Fix phpstan level 6 issues

### DIFF
--- a/lib/IDS/Caching/ApcCache.php
+++ b/lib/IDS/Caching/ApcCache.php
@@ -51,7 +51,7 @@ class ApcCache implements CacheInterface
     /**
      * Cache configuration
      *
-     * @var array
+     * @var array<string, mixed>
      */
     private $config = null;
 
@@ -100,7 +100,7 @@ class ApcCache implements CacheInterface
     /**
      * Writes cache data
      *
-     * @param array $data the caching data
+     * @param array<int|string, mixed> $data the caching data
      *
      * @return object $this
      */

--- a/lib/IDS/Caching/CacheInterface.php
+++ b/lib/IDS/Caching/CacheInterface.php
@@ -49,7 +49,7 @@ interface CacheInterface
     /**
      * Interface method
      *
-     * @param array $data the cache data
+     * @param array<int|string, mixed> $data the cache data
      *
      * @return void
      */

--- a/lib/IDS/Caching/DatabaseCache.php
+++ b/lib/IDS/Caching/DatabaseCache.php
@@ -81,7 +81,7 @@ class DatabaseCache implements CacheInterface
     /**
      * Cache configuration
      *
-     * @var array
+     * @var array<string, mixed>
      */
     private $config = null;
 
@@ -138,7 +138,7 @@ class DatabaseCache implements CacheInterface
     /**
      * Writes cache data into the database
      *
-     * @param array $data the caching data
+     * @param array<int|string, mixed> $data the caching data
      *
      * @throws \PDOException if a db error occurred
      * @return object       $this
@@ -236,7 +236,7 @@ class DatabaseCache implements CacheInterface
      * Write the cache data to the table
      *
      * @param object $handle the database handle
-     * @param array  $data   the caching data
+     * @param array<int|string, mixed>  $data   the caching data
      *
      * @return void
      * @throws \PDOException if a db error occurred

--- a/lib/IDS/Caching/FileCache.php
+++ b/lib/IDS/Caching/FileCache.php
@@ -54,7 +54,7 @@ class FileCache implements CacheInterface
     /**
      * Cache configuration
      *
-     * @var array
+     * @var array<string, mixed>
      */
     private $config;
 
@@ -113,7 +113,7 @@ class FileCache implements CacheInterface
     /**
      * Writes cache data into the file
      *
-     * @param array $data the cache data
+     * @param array<int|string, mixed> $data the cache data
      *
      * @throws \Exception if cache file couldn't be created
      * @return object    $this

--- a/lib/IDS/Caching/MemcachedCache.php
+++ b/lib/IDS/Caching/MemcachedCache.php
@@ -52,7 +52,7 @@ class MemcachedCache implements CacheInterface
     /**
      * Cache configuration
      *
-     * @var array
+     * @var array<string, mixed>
      */
     private $config = null;
 
@@ -111,7 +111,7 @@ class MemcachedCache implements CacheInterface
     /**
      * Writes cache data
      *
-     * @param array $data the caching data
+     * @param array<int|string, mixed> $data the caching data
      *
      * @return object $this
      */

--- a/lib/IDS/Caching/SessionCache.php
+++ b/lib/IDS/Caching/SessionCache.php
@@ -59,7 +59,7 @@ class SessionCache implements CacheInterface
     /**
      * Cache configuration
      *
-     * @var array
+     * @var array<string, mixed>
      */
     private $config = null;
 
@@ -105,7 +105,7 @@ class SessionCache implements CacheInterface
     /**
      * Writes cache data into the session
      *
-     * @param array $data the caching data
+     * @param array<int|string, mixed> $data the caching data
      *
      * @return object $this
      */

--- a/lib/IDS/Event.php
+++ b/lib/IDS/Event.php
@@ -48,6 +48,8 @@ namespace IDS;
  * @copyright 2007-2009 The PHPIDS Group
  * @license   http://www.gnu.org/licenses/lgpl.html LGPL
  * @link      http://php-ids.org/
+ *
+ * @implements \IteratorAggregate<int, Filter>
  */
 class Event implements \Countable, \IteratorAggregate
 {

--- a/lib/IDS/Filter/Storage.php
+++ b/lib/IDS/Filter/Storage.php
@@ -62,7 +62,7 @@ class Storage
     /**
      * Holds caching settings
      *
-     * @var array
+     * @var array<string, mixed>|null
      */
     protected $cacheSettings = null;
 
@@ -76,7 +76,7 @@ class Storage
     /**
      * Filter container
      *
-     * @var array
+     * @var \IDS\Filter[]
      */
     protected $filterSet = array();
 
@@ -120,11 +120,11 @@ class Storage
     /**
      * Sets the filter array
      *
-     * @param array $filterSet array containing multiple IDS_Filter instances
+     * @param \IDS\Filter[] $filterSet array containing multiple IDS_Filter instances
      *
      * @return object $this
      */
-    final public function setFilterSet($filterSet)
+    final public function setFilterSet(array $filterSet)
     {
         foreach ($filterSet as $filter) {
             $this->addFilter($filter);
@@ -136,7 +136,7 @@ class Storage
     /**
      * Returns registered filters
      *
-     * @return array
+     * @return \IDS\Filter[]
      */
     final public function getFilterSet()
     {
@@ -377,7 +377,8 @@ class Storage
      * This functions adds an array of filters to the IDS_Storage object.
      * Each entry within the array is expected to be an simple array containing all parts of the filter.
      * 
-     * @param array $filters
+     * @param array<int, array<string, mixed>> $filters
+     * @return void
      */
     private function addFiltersFromArray(array $filters)
     {

--- a/lib/IDS/Init.php
+++ b/lib/IDS/Init.php
@@ -52,7 +52,7 @@ class Init
     /**
      * Holds config settings
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $config = array();
 
@@ -69,7 +69,7 @@ class Init
      *
      * Includes needed classes and parses the configuration file
      *
-     * @param array $config
+     * @param array<string, mixed> $config
      *
      * @return \IDS\Init $this
      */
@@ -119,7 +119,7 @@ class Init
     /**
      * Merges new settings into the exsiting ones or overwrites them
      *
-     * @param array   $config    the config array
+     * @param array<string, mixed>   $config    the config array
      * @param boolean $overwrite config overwrite flag
      *
      * @return void
@@ -140,9 +140,9 @@ class Init
      * an array in both, the values will be appended. If it is a scalar in both,
      * the value will be replaced.
      *
-     * @param  array $current   The legacy hash
-     * @param  array $successor The hash which values count more when in doubt
-     * @return array Merged hash
+     * @param  array<string, mixed> $current   The legacy hash
+     * @param  array<string, mixed> $successor The hash which values count more when in doubt
+     * @return array<string, mixed> Merged hash
      */
     protected function mergeConfig(array $current, array $successor)
     {
@@ -163,7 +163,7 @@ class Init
     /**
      * Returns the config array
      *
-     * @return array the config array
+     * @return array<string, mixed> the config array
      */
     public function getConfig()
     {

--- a/lib/IDS/Monitor.php
+++ b/lib/IDS/Monitor.php
@@ -56,7 +56,7 @@ class Monitor
      *
      * Accepted values are xss, csrf, sqli, dt, id, lfi, rfe, spam, dos
      *
-     * @var array
+     * @var string[]|null
      */
     private $tags = null;
 
@@ -85,7 +85,7 @@ class Monitor
      * Using this array it is possible to define variables that must not be
      * scanned. Per default, utmz google analytics parameters are permitted.
      *
-     * @var array
+     * @var string[]
      */
     private $exceptions = array();
 
@@ -96,7 +96,7 @@ class Monitor
      * contain html and have to be prepared before hitting the rules to
      * avoid too many false alerts
      *
-     * @var array
+     * @var string[]
      */
     private $html = array();
 
@@ -106,7 +106,7 @@ class Monitor
      * Using this array it is possible to define variables that contain
      * JSON data - and should be treated as such
      *
-     * @var array
+     * @var string[]
      */
     private $json = array();
 
@@ -134,7 +134,7 @@ class Monitor
     /**
      * Centrifuge data container
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $centrifuge = array();
 
@@ -144,7 +144,7 @@ class Monitor
      * @throws \InvalidArgumentException When PHP version is less than what the library supports
      * @throws \Exception
      * @param  Init       $init instance of IDS_Init
-     * @param  array|null $tags list of tags to which filters should be applied
+     * @param  string[]|null $tags list of tags to which filters should be applied
      * @return Monitor
      */
     public function __construct(Init $init, ?array $tags = null)
@@ -170,7 +170,7 @@ class Monitor
     /**
      * Starts the scan mechanism
      *
-     * @param  array $request
+     * @param  array<string, mixed> $request
      * @return Report
      */
     public function run(array $request)
@@ -187,7 +187,7 @@ class Monitor
      * order to check for malicious appearing fragments
      *
      * @param string       $key   the former array key
-     * @param array|string $value the former array value
+     * @param array<string, mixed>|string $value the former array value
      * @param Report       $report
      * @return Report
      */
@@ -289,7 +289,7 @@ class Monitor
      * @since  0.5
      * @throws \Exception
      *
-     * @return array tuple [key,value]
+     * @return array{0:mixed,1:mixed} tuple [key,value]
      */
     private function purifyValues($key, $value)
     {
@@ -420,9 +420,9 @@ class Monitor
      * @param string $value
      * @since  0.5.3
      *
-     * @return array tuple [key,value]
-     */
-    private function jsonDecodeValues($key, $value)
+     * @return array{0:mixed,1:mixed} tuple [key,value]
+    */
+   private function jsonDecodeValues($key, $value)
     {
         $decodedKey   = json_decode($key);
         $decodedValue = json_decode($value);
@@ -478,9 +478,9 @@ class Monitor
     /**
      * Returns exception array
      *
-     * @return array
-     */
-    public function getExceptions()
+     * @return string[]
+    */
+   public function getExceptions()
     {
         return $this->exceptions;
     }
@@ -516,9 +516,9 @@ class Monitor
      *
      * @since 0.5
      *
-     * @return array the fields that contain allowed html
-     */
-    public function getHtml()
+     * @return string[] the fields that contain allowed html
+    */
+   public function getHtml()
     {
         return $this->html;
     }
@@ -554,9 +554,9 @@ class Monitor
      *
      * @since 0.5.3
      *
-     * @return array the fields that contain json
-     */
-    public function getJson()
+     * @return string[] the fields that contain json
+    */
+   public function getJson()
     {
         return $this->json;
     }

--- a/lib/IDS/Report.php
+++ b/lib/IDS/Report.php
@@ -49,6 +49,9 @@ namespace IDS;
  * @license   http://www.gnu.org/licenses/lgpl.html LGPL
  * @link      http://php-ids.org/
  */
+/**
+ * @implements \IteratorAggregate<string, Event>
+ */
 class Report implements \Countable, \IteratorAggregate
 {
     /**
@@ -84,14 +87,14 @@ class Report implements \Countable, \IteratorAggregate
      * This variable - initiated as an empty array - carries all information
      * about the centrifuge data if available
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $centrifuge = array();
 
     /**
      * Constructor
      *
-     * @param array $events the events the report should include
+     * @param Event[]|null $events the events the report should include
      *
      * @return Report
      */
@@ -245,7 +248,7 @@ class Report implements \Countable, \IteratorAggregate
      * This method returns the centrifuge property or null if not
      * filled with data
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getCentrifuge()
     {
@@ -255,7 +258,7 @@ class Report implements \Countable, \IteratorAggregate
     /**
      * This method sets the centrifuge property
      *
-     * @param array $centrifuge the centrifuge data
+     * @param array<string, mixed> $centrifuge the centrifuge data
      *
      * @throws \InvalidArgumentException if argument is illegal
      * @return void


### PR DESCRIPTION
## Summary
- add array value type annotations across the codebase so phpstan level 6 passes

## Testing
- `./vendor/bin/phpstan analyze -l 6 -c phpstan.neon`

------
https://chatgpt.com/codex/tasks/task_e_685f1255464483259f33340b0b4a3d03