### PR TITLE
Run phpstan at level 7 and fix reported issues

### DIFF
--- a/lib/IDS/Caching/CacheFactory.php
+++ b/lib/IDS/Caching/CacheFactory.php
@@ -52,10 +52,10 @@ class CacheFactory
     /**
      * Factory method
      *
-     * @param object $init the IDS_Init object
+     * @param \IDS\Init $init the IDS_Init object
      * @param string $type the caching type
      *
-     * @return object the caching facility
+     * @return \IDS\Caching\CacheInterface|false the caching facility
      */
     public static function factory($init, $type)
     {

--- a/lib/IDS/Caching/CacheInterface.php
+++ b/lib/IDS/Caching/CacheInterface.php
@@ -58,7 +58,7 @@ interface CacheInterface
     /**
      * Interface method
      *
-     * @return void
+     * @return mixed
      */
     public function getCache();
 }

--- a/lib/IDS/Caching/DatabaseCache.php
+++ b/lib/IDS/Caching/DatabaseCache.php
@@ -201,11 +201,11 @@ class DatabaseCache implements CacheInterface
     /**
      * Connect to database and return a handle
      *
-     * @return object       PDO
+     * @return \PDO       PDO
      * @throws \Exception    if connection parameters are faulty
      * @throws \PDOException if a db error occurred
      */
-    private function connect()
+    private function connect(): \PDO
     {
         // validate connection parameters
         if (!$this->config['wrapper']
@@ -235,13 +235,13 @@ class DatabaseCache implements CacheInterface
     /**
      * Write the cache data to the table
      *
-     * @param object $handle the database handle
+     * @param \PDO   $handle the database handle
      * @param array<int|string, mixed>  $data   the caching data
      *
      * @return void
      * @throws \PDOException if a db error occurred
      */
-    private function write($handle, $data)
+    private function write(\PDO $handle, $data)
     {
         try {
             $handle->query('TRUNCATE ' . $this->config['table'].'');

--- a/lib/IDS/Caching/FileCache.php
+++ b/lib/IDS/Caching/FileCache.php
@@ -162,7 +162,12 @@ class FileCache implements CacheInterface
             return false;
         }
 
-        $data = unserialize(file_get_contents($this->path));
+        $content = file_get_contents($this->path);
+        if ($content === false) {
+            return false;
+        }
+
+        $data = unserialize($content);
 
         return $data;
     }

--- a/lib/IDS/Caching/MemcachedCache.php
+++ b/lib/IDS/Caching/MemcachedCache.php
@@ -66,7 +66,7 @@ class MemcachedCache implements CacheInterface
     /**
      * Memcache object
      *
-     * @var object
+     * @var \Memcache|null
      */
     private $memcache = null;
 
@@ -118,12 +118,12 @@ class MemcachedCache implements CacheInterface
     public function setCache(array $data)
     {
         if (!$this->isCached) {
-            $this->memcache->set(
-                $this->config['key_prefix'] . '.storage',
-                $data,
-                false,
-                $this->config['expiration_time']
-            );
+                $this->memcache->set(
+                    $this->config['key_prefix'] . '.storage',
+                    $data,
+                    0,
+                    $this->config['expiration_time']
+                );
         }
 
         return $this;

--- a/lib/IDS/Caching/SessionCache.php
+++ b/lib/IDS/Caching/SessionCache.php
@@ -56,12 +56,6 @@ class SessionCache implements CacheInterface
      */
     private $type = null;
 
-    /**
-     * Cache configuration
-     *
-     * @var array<string, mixed>
-     */
-    private $config = null;
 
     /**
      * Holds an instance of this class
@@ -74,21 +68,21 @@ class SessionCache implements CacheInterface
      * Constructor
      *
      * @param string $type caching type
-     * @param object $init the IDS_Init object
+     * @param \IDS\Init $init the IDS_Init object
      *
      * @return void
      */
     public function __construct($type, $init)
     {
         $this->type   = $type;
-        $this->config = $init->config['Caching'];
+        unset($init);
     }
 
     /**
      * Returns an instance of this class
      *
-     * @param string $type caching type
-     * @param object $init the IDS_Init object
+     * @param string   $type caching type
+     * @param \IDS\Init $init the IDS_Init object
      *
      * @return object $this
      */

--- a/lib/IDS/Converter.php
+++ b/lib/IDS/Converter.php
@@ -154,9 +154,11 @@ class Converter
 
                 if (preg_match_all('/\d*[+-\/\* ]\d+/', $char, $matches)) {
                     $match = preg_split('/(\W?\d+)/', implode('', $matches[0]), -1, PREG_SPLIT_DELIM_CAPTURE);
+                    $match = $match === false ? [] : $match;
 
-                    if (array_sum($match) >= 20 && array_sum($match) <= 127) {
-                        $converted .= chr(array_sum($match));
+                    $sum = array_sum($match);
+                    if ($sum >= 20 && $sum <= 127) {
+                        $converted .= chr((int) $sum);
                     }
 
                 } elseif (!empty($char) && $char >= 20 && $char <= 127) {
@@ -174,7 +176,7 @@ class Converter
 
             foreach (array_map('octdec', array_filter($charcode)) as $char) {
                 if (20 <= $char && $char <= 127) {
-                    $converted .= chr($char);
+                    $converted .= chr((int) $char);
                 }
             }
             $value .= "\n" . $converted;
@@ -187,7 +189,7 @@ class Converter
 
             foreach (array_map('hexdec', array_filter($charcode)) as $char) {
                 if (20 <= $char && $char <= 127) {
-                    $converted .= chr($char);
+                    $converted .= chr((int) $char);
                 }
             }
             $value .= "\n" . $converted;
@@ -276,7 +278,7 @@ class Converter
                 $converted = '';
                 foreach (str_split($match, 2) as $hex_index) {
                     if (preg_match('/[a-f\d]{2,3}/i', $hex_index)) {
-                        $converted .= chr(hexdec($hex_index));
+                        $converted .= chr((int) hexdec($hex_index));
                     }
                 }
                 $value = str_replace($match, $converted, $value);
@@ -478,7 +480,7 @@ class Converter
 
         if (!empty($matches[0])) {
             foreach ($matches[0] as $match) {
-                $chr = chr(hexdec(substr($match, 2, 4)));
+                $chr = chr((int) hexdec(substr($match, 2, 4)));
                 $value = str_replace($match, $chr, $value);
             }
             $value .= "\n\u0001";

--- a/lib/IDS/Filter/Storage.php
+++ b/lib/IDS/Filter/Storage.php
@@ -69,7 +69,7 @@ class Storage
     /**
      * Cache container
      *
-     * @var object|null IDS_Caching wrapper
+     * @var \IDS\Caching\CacheInterface|null IDS_Caching wrapper
      */
     protected $cache = null;
 
@@ -101,7 +101,10 @@ class Storage
 
             if ($caching && $caching !== 'none') {
                 $this->cacheSettings = $init->config['Caching'];
-                $this->cache = CacheFactory::factory($init, 'storage');
+                $cache = CacheFactory::factory($init, 'storage');
+                if ($cache instanceof \IDS\Caching\CacheInterface) {
+                    $this->cache = $cache;
+                }
             }
 
             switch ($type) {
@@ -309,7 +312,11 @@ class Storage
                         sprintf('Invalid config: %s doesn\'t exist.', $this->source)
                     );
                 }
-                $filters = json_decode(file_get_contents($this->source));
+                $json = file_get_contents($this->source);
+                if ($json === false) {
+                    throw new \RuntimeException('JSON file could not be read.');
+                }
+                $filters = json_decode($json);
             }
 
             if (!$filters) {

--- a/lib/IDS/Init.php
+++ b/lib/IDS/Init.php
@@ -96,7 +96,11 @@ class Init
             if (!file_exists($configPath) || !is_readable($configPath)) {
                 throw new \InvalidArgumentException("Invalid config path '$configPath'");
             }
-            self::$instances[$configPath] = new self(parse_ini_file($configPath, true));
+            $parsed = parse_ini_file($configPath, true);
+            if ($parsed === false) {
+                throw new \RuntimeException("Unable to parse config file '$configPath'");
+            }
+            self::$instances[$configPath] = new self($parsed);
         }
 
         return self::$instances[$configPath];

--- a/lib/IDS/Monitor.php
+++ b/lib/IDS/Monitor.php
@@ -395,11 +395,14 @@ class Monitor
         $array1 = preg_split('/(?<!^)(?!$)/u', html_entity_decode(urldecode($original)));
         $array2 = preg_split('/(?<!^)(?!$)/u', $purified);
 
-        // create an array containing the single character differences
-        $differences = array_diff_assoc($array1, $array2);
-
+        if ($array1 === false || $array2 === false) {
+            $differences = '';
+        } else {
+            // create an array containing the single character differences
+            $differences = implode('', array_diff_assoc($array1, $array2));
+        }
         // return the diff - ready to hit the converter and the rules
-        $differences = trim(implode('', $differences));
+        $differences = trim($differences);
         $diff = $length <= 10 ? $differences : mb_substr($differences, 0, strlen($original));
 
         // clean up spaces between tag delimiters
@@ -459,7 +462,12 @@ class Monitor
         if (is_string($key) && is_string($value)) {
             $this->tmpJsonString .=  $key . " " . $value . "\n";
         } else {
-            $this->jsonDecodeValues(json_encode($key), json_encode($value));
+            $encodedKey = json_encode($key);
+            $encodedValue = json_encode($value);
+            $this->jsonDecodeValues(
+                $encodedKey === false ? '' : $encodedKey,
+                $encodedValue === false ? '' : $encodedValue
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- raise phpstan checks to level 7 and resolve all warnings
- tighten return types for database cache connection
- handle file reading failures in file and JSON caches
- improve monitor diff logic and JSON handling
- fix converter integer casts
- annotate cache interface correctly

## Testing
- `vendor/bin/phpstan analyse -c phpstan.neon -l 7 lib`

------
https://chatgpt.com/codex/tasks/task_e_685f14f450d883258e91a86d89b9ab16