### PR TITLE
Run phpstan level 8 and fix issues

### DIFF
--- a/lib/IDS/Caching/DatabaseCache.php
+++ b/lib/IDS/Caching/DatabaseCache.php
@@ -88,9 +88,9 @@ class DatabaseCache implements CacheInterface
     /**
      * Database connection handle
      *
-     * @var \PDO|null
+     * @var \PDO
      */
-    private $handle = null;
+    private $handle;
 
     /**
      * Holds an instance of this class

--- a/lib/IDS/Caching/FileCache.php
+++ b/lib/IDS/Caching/FileCache.php
@@ -120,7 +120,8 @@ class FileCache implements CacheInterface
      */
     public function setCache(array $data)
     {
-        if (!is_writable(preg_replace('/[\/][^\/]+\.[^\/]++$/', '', $this->path))) {
+        $directory = dirname($this->path);
+        if (!is_writable($directory)) {
             throw new \Exception(
                 'Temp directory ' .
                 htmlspecialchars($this->path, ENT_QUOTES, 'UTF-8') .

--- a/lib/IDS/Caching/MemcachedCache.php
+++ b/lib/IDS/Caching/MemcachedCache.php
@@ -66,9 +66,9 @@ class MemcachedCache implements CacheInterface
     /**
      * Memcache object
      *
-     * @var \Memcache|null
+     * @var \Memcache
      */
-    private $memcache = null;
+    private $memcache;
 
     /**
      * Holds an instance of this class

--- a/lib/IDS/Converter.php
+++ b/lib/IDS/Converter.php
@@ -94,16 +94,16 @@ class Converter
                 '/(?:--[^-]*-)/ms'
             );
 
-            $converted = preg_replace($pattern, ';', $value);
+            $converted = (string) preg_replace($pattern, ';', $value);
             $value    .= "\n" . $converted;
         }
 
         //make sure inline comments are detected and converted correctly
-        $value = preg_replace('/(<\w+)\/+(\w+=?)/m', '$1/$2', $value);
-        $value = preg_replace('/[^\\\:]\/\/(.*)$/m', '/**/$1', $value);
-        $value = preg_replace('/([^\-&])#.*[\r\n\v\f]/m', '$1', $value);
-        $value = preg_replace('/([^&\-])#.*\n/m', '$1 ', $value);
-        $value = preg_replace('/^#.*\n/m', ' ', $value);
+        $value = (string) preg_replace('/(<\w+)\/+(\w+=?)/m', '$1/$2', $value);
+        $value = (string) preg_replace('/[^\\\:]\/\/(.*)$/m', '/**/$1', $value);
+        $value = (string) preg_replace('/([^\-&])#.*[\r\n\v\f]/m', '$1', $value);
+        $value = (string) preg_replace('/([^&\-])#.*\n/m', '$1 ', $value);
+        $value = (string) preg_replace('/^#.*\n/m', ' ', $value);
 
         return $value;
     }
@@ -126,7 +126,7 @@ class Converter
         $value = str_replace('�', ' ', $value);
 
         //convert real linebreaks
-        return preg_replace('/(?:\n|\r|\v)/m', '  ', $value);
+        return (string) preg_replace('/(?:\n|\r|\v)/m', '  ', $value);
     }
 
     /**
@@ -725,8 +725,10 @@ class Converter
             );
 
             if ($stripped_length != 0 && $overall_length/$stripped_length <= $threshold) {
-                $monitor->centrifuge['ratio']     = $overall_length / $stripped_length;
-                $monitor->centrifuge['threshold'] =$threshold;
+                if ($monitor !== null) {
+                    $monitor->centrifuge['ratio']     = $overall_length / $stripped_length;
+                    $monitor->centrifuge['threshold'] = $threshold;
+                }
 
                 $value .= "\n$[!!!]";
             }
@@ -770,7 +772,9 @@ class Converter
             $converted = implode($array);
 
             if (preg_match('/(?:\({2,}\+{2,}:{2,})|(?:\({2,}\+{2,}:+)|(?:\({3,}\++:{2,})/', $converted)) {
-                $monitor->centrifuge['converted'] = $converted;
+                if ($monitor !== null) {
+                    $monitor->centrifuge['converted'] = $converted;
+                }
 
                 return $value . "\n" . $converted;
             }

--- a/lib/IDS/Filter/Storage.php
+++ b/lib/IDS/Filter/Storage.php
@@ -267,7 +267,7 @@ class Storage
                 /*
                  * If caching is enabled, the fetched data will be cached
                 */
-                if ($this->cacheSettings) {
+                if ($this->cacheSettings && $this->cache !== null) {
                     $this->cache->setCache($data);
                 }
                 
@@ -364,7 +364,7 @@ class Storage
                 /*
                  * If caching is enabled, the fetched data will be cached
                  */
-                if ($this->cacheSettings) {
+                if ($this->cacheSettings && $this->cache !== null) {
                     $this->cache->setCache($data);
                 }
                 

--- a/lib/IDS/Monitor.php
+++ b/lib/IDS/Monitor.php
@@ -357,7 +357,7 @@ class Monitor
      * @param string $plain    the string without html
      * @since 0.5
      *
-     * @return string the difference between the strings
+     * @return string|null the difference between the strings
      */
     private function diff($original, $purified, $plain)
     {


### PR DESCRIPTION
## Summary
- run phpstan on level 8
- fix obvious nullable issues in caching classes
- ensure centrifuge metrics only stored when monitor is present
- adjust FileCache directory handling
- clarify nullable return for Monitor::diff

## Testing
- `./vendor/bin/phpstan analyse -l 8 -c phpstan.neon`

------
https://chatgpt.com/codex/tasks/task_e_685f16cf3b44832583dfaf92f4e7c14e