### PR TITLE
Run phpstan at level 9 and fix some issues

### DIFF
--- a/lib/IDS/Caching/ApcCache.php
+++ b/lib/IDS/Caching/ApcCache.php
@@ -78,7 +78,9 @@ class ApcCache implements CacheInterface
      */
     public function __construct($init)
     {
-        $this->config = $init->config['Caching'];
+        /** @var array<string, mixed> $config */
+        $config = $init->config['Caching'];
+        $this->config = $config;
     }
 
     /**
@@ -107,10 +109,12 @@ class ApcCache implements CacheInterface
     public function setCache(array $data)
     {
         if (!$this->isCached) {
+            /** @var int $ttl */
+            $ttl = $this->config['expiration_time'];
             apc_store(
                 $this->config['key_prefix'] . '.storage',
                 $data,
-                $this->config['expiration_time']
+                $ttl
             );
         }
 

--- a/lib/IDS/Caching/CacheFactory.php
+++ b/lib/IDS/Caching/CacheFactory.php
@@ -57,13 +57,14 @@ class CacheFactory
      *
      * @return \IDS\Caching\CacheInterface|false the caching facility
      */
-    public static function factory($init, $type)
+    public static function factory($init, $type): CacheInterface|false
     {
         $object  = false;
+        $config  = (array) $init->config['Caching'];
         $wrapper = preg_replace(
             '/\W+/m',
             '',
-            ucfirst($init->config['Caching']['caching'])
+            ucfirst((string) $config['caching'])
         );
         $class   = '\\IDS\\Caching\\' . $wrapper . 'Cache';
         $path    = dirname(__FILE__) . DIRECTORY_SEPARATOR . $wrapper . 'Cache.php';

--- a/lib/IDS/Caching/DatabaseCache.php
+++ b/lib/IDS/Caching/DatabaseCache.php
@@ -112,7 +112,9 @@ class DatabaseCache implements CacheInterface
     public function __construct($type, $init)
     {
         $this->type   = $type;
-        $this->config = $init->config['Caching'];
+        /** @var array<string, mixed> $config */
+        $config       = $init->config['Caching'];
+        $this->config = $config;
         $this->handle = $this->connect();
     }
 
@@ -156,8 +158,10 @@ class DatabaseCache implements CacheInterface
 
             foreach ($rows as $row) {
 
-                if ((time()-strtotime($row['created'])) >
-                    $this->config['expiration_time']) {
+                /** @var int $ttl */
+                $ttl = $this->config['expiration_time'];
+                if ((time() - strtotime((string) $row['created'])) >
+                    $ttl) {
 
                     $this->write($handle, $data);
                 }
@@ -188,7 +192,9 @@ class DatabaseCache implements CacheInterface
             $result->execute(array($this->type));
 
             foreach ($result as $row) {
-                return unserialize($row['data']);
+                /** @var string $data */
+                $data = $row['data'];
+                return unserialize($data);
             }
 
         } catch (\PDOException $e) {
@@ -218,10 +224,16 @@ class DatabaseCache implements CacheInterface
 
         // try to connect
         try {
+            /** @var string $dsn */
+            $dsn = $this->config['wrapper'];
+            /** @var string $user */
+            $user = $this->config['user'];
+            /** @var string $password */
+            $password = $this->config['password'];
             $handle = new \PDO(
-                $this->config['wrapper'],
-                $this->config['user'],
-                $this->config['password']
+                $dsn,
+                $user,
+                $password
             );
             $handle->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
 

--- a/lib/IDS/Caching/FileCache.php
+++ b/lib/IDS/Caching/FileCache.php
@@ -82,7 +82,9 @@ class FileCache implements CacheInterface
      */
     public function __construct(Init $init)
     {
-        $this->config = $init->config['Caching'];
+        /** @var array<string, mixed> $config */
+        $config = $init->config['Caching'];
+        $this->config = $config;
         $this->path   = $init->getBasePath() . $this->config['path'];
 
         if (file_exists($this->path) && !is_writable($this->path)) {
@@ -181,6 +183,8 @@ class FileCache implements CacheInterface
      */
     private function isValidFile($file)
     {
-        return file_exists($file) && time() - filectime($file) <= $this->config['expiration_time'];
+        /** @var int $ttl */
+        $ttl = $this->config['expiration_time'];
+        return file_exists($file) && time() - filectime($file) <= $ttl;
     }
 }

--- a/lib/IDS/Caching/MemcachedCache.php
+++ b/lib/IDS/Caching/MemcachedCache.php
@@ -86,8 +86,10 @@ class MemcachedCache implements CacheInterface
      */
     public function __construct($init)
     {
-        
-        $this->config = $init->config['Caching'];
+
+        /** @var array<string, mixed> $config */
+        $config = $init->config['Caching'];
+        $this->config = $config;
 
         $this->connect();
     }
@@ -118,11 +120,13 @@ class MemcachedCache implements CacheInterface
     public function setCache(array $data)
     {
         if (!$this->isCached) {
+                /** @var int $ttl */
+                $ttl = $this->config['expiration_time'];
                 $this->memcache->set(
                     $this->config['key_prefix'] . '.storage',
                     $data,
                     0,
-                    $this->config['expiration_time']
+                    $ttl
                 );
         }
 
@@ -160,9 +164,13 @@ class MemcachedCache implements CacheInterface
         if ($this->config['host'] && $this->config['port']) {
             // establish the memcache connection
             $this->memcache = new \Memcache;
+            /** @var string $host */
+            $host = $this->config['host'];
+            /** @var int $port */
+            $port = $this->config['port'];
             $this->memcache->pconnect(
-                $this->config['host'],
-                $this->config['port']
+                $host,
+                $port
             );
 
         } else {


### PR DESCRIPTION
## Summary
- annotate cache configs so phpstan knows the expected types
- cast expiration time, host and port via local vars
- improve return type handling of CacheFactory

## Testing
- `vendor/bin/phpstan analyse --level=9`

------
https://chatgpt.com/codex/tasks/task_e_685f18413af08325a922dd14395db87f